### PR TITLE
Allow ENV's value to be 0 or empty string

### DIFF
--- a/src/EnvAccessor.php
+++ b/src/EnvAccessor.php
@@ -31,9 +31,11 @@ class EnvAccessor
             if ($this->localOnly) {
                 trigger_error('localOnly option is only available in PHP 7');
             }
-            return getenv($key) ?: $default;
+            $value = getenv($key);
+            return $value === false ? $default : $value;
         }
-        return getenv($key, $this->localOnly) ?: $default;
+        $value = getenv($key, $this->localOnly);
+        return $value === false ? $default : $value;
     }
 
     private function load()

--- a/tests/.env
+++ b/tests/.env
@@ -3,3 +3,4 @@ somethingelse=somethingelse
 percent=some%20string%20
 empty=
 zero=0
+false=false

--- a/tests/.env
+++ b/tests/.env
@@ -1,3 +1,5 @@
 something=something
 somethingelse=somethingelse
 percent=some%20string%20
+empty=
+zero=0

--- a/tests/EnvAccessorTest.php
+++ b/tests/EnvAccessorTest.php
@@ -39,9 +39,30 @@ class EnvAccessorTest extends \PHPUnit_Framework_TestCase
         $ts = new EnvAccessor(__DIR__);
         $this->assertEquals('some%20string%20', $ts->get('percent'));
     }
-    public function testReturnsDefaultOnNonExistent()
+
+    public function testReturnsDefaultForNonExistentWithDefault()
     {
         $ts = new EnvAccessor(__DIR__);
         $this->assertEquals('default', $ts->get('some_non_existing_key', 'default'));
+    }
+
+    public function testReturnsNullForNonExistentWithoutDefault()
+    {
+        $ts = new EnvAccessor(__DIR__);
+        $this->assertNull($ts->get('some_non_existing_key'));
+    }
+
+    public function testReturnsEmptyStringForEmpty()
+    {
+        $ts = new EnvAccessor(__DIR__);
+        $this->assertNotNull($ts->get('empty'));
+        $this->assertSame('', $ts->get('empty'));
+    }
+
+    public function testReturnsZeroStringForZero()
+    {
+        $ts = new EnvAccessor(__DIR__);
+        $this->assertNotNull($ts->get('zero'));
+        $this->assertSame('0', $ts->get('zero'));
     }
 }

--- a/tests/EnvAccessorTest.php
+++ b/tests/EnvAccessorTest.php
@@ -65,4 +65,11 @@ class EnvAccessorTest extends \PHPUnit_Framework_TestCase
         $this->assertNotNull($ts->get('zero'));
         $this->assertSame('0', $ts->get('zero'));
     }
+
+    public function testReturnsFalseStringForFalse()
+    {
+        $ts = new EnvAccessor(__DIR__);
+        $this->assertNotNull($ts->get('false'));
+        $this->assertSame('false', $ts->get('false'));
+    }
 }


### PR DESCRIPTION
Accessor should respect variables with empty value or value equal to 0 and should not return `NULL`/_default value_ for them.

Zero - it's obvious bug caused by loose comparison.
Empty value - IMO, a variable set to empty value it's something else then variable which isn't set at all. Therefore _Accessor_ should return that empty value rather than NULL.