### PR TITLE
Fixed small typo in Configuration section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ env:
 	overload: false
 	localOnly: false
 	prefix: false
-	class: "\wodCZ\NetteDotenv\EnvAccessor"
+	class: \wodCZ\NetteDotenv\EnvAccessor
 ```
 
 | Option | Description |


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Readme documentation fixed. The configuration section suggested steps that would inevitably result in an application failure.

The mentioned situation happens at least on nette version 2.3.

The failure stems from backslash characters nested within double-quotes. The attached file contains nette Tracy red exception debug page (w/o parts containing sensitive data).

[Nette\Neon\Exception-Invalid_escaping_sequence.html.gz](https://github.com/wodCZ/nette-dotenv/files/1677711/Nette.Neon.Exception-Invalid_escaping_sequence.html.gz)


## Motivation and context

Why is this change required? What problem does it solve?

It has to be changed in order not to mystify users about how to configure the extension:-)

## How has this been tested?

By eyes?

## Screenshots (if appropriate)

Please see the Tracy dump attached.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation improvement

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [ x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [ x] My pull request addresses exactly one patch/feature.
- [ x] I have created a branch for this patch/feature.
- [ x] Each individual commit in the pull request is meaningful.
- [ -] I have added tests to cover my changes. (Cannot do tests for documentation)
- [ x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
